### PR TITLE
feat: improve block type definition

### DIFF
--- a/src/lib/__snapshots__/build-types.spec.ts.snap
+++ b/src/lib/__snapshots__/build-types.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`buildTypes > should handle current fixtures without throwing 1`] = `
-"import { type BaseDocumentType, type EmptyObjectType, type BaseGridBlockType, type BaseBlockType, type BaseGridBlockAreaType, type BaseBlockListType, type BaseBlockGridType, type BaseMediaType, type Crop, type MediaPickerItem } from "./base-types";
+"import { type BaseDocumentType, type BaseElementType, type EmptyObjectType, type BaseGridBlockType, type BaseBlockType, type BaseGridBlockAreaType, type BaseBlockListType, type BaseBlockGridType, type BaseMediaType, type Crop, type MediaPickerItem } from "./base-types";
 import { type UmbracoForm } from "./form";
 
 export interface UrlItem {
@@ -182,21 +182,21 @@ export type UmbracoMediaVideo = BaseMediaType<"umbracoMediaVideo", {
 
 export type PickableMediaType = ImageWithProps | File | UmbracoMediaArticle | UmbracoMediaAudio | UmbracoMediaVectorGraphics | Image | Folder | UmbracoMediaVideo;
 
-export type UmbBlockGridDemoTwoColumnLayoutBlock = BaseDocumentType<"umbBlockGridDemoTwoColumnLayoutBlock", EmptyObjectType>;
+export type UmbBlockGridDemoTwoColumnLayoutBlock = BaseElementType<"umbBlockGridDemoTwoColumnLayoutBlock", EmptyObjectType>;
 
 export type ContentPage = BaseDocumentType<"contentPage", Metadata["properties"] & PageSettings["properties"] & {
     blocks?: ContentBlockList;
 }>;
 
-export type LinkItem = BaseDocumentType<"linkItem", {
+export type LinkItem = BaseElementType<"linkItem", {
     link: unknown;
 }>;
 
-export type RichtextBlock = BaseDocumentType<"richtextBlock", {
+export type RichtextBlock = BaseElementType<"richtextBlock", {
     content?: RichtextEditor;
 }>;
 
-export type UmbBlockGridDemoRichTextBlock = BaseDocumentType<"umbBlockGridDemoRichTextBlock", {
+export type UmbBlockGridDemoRichTextBlock = BaseElementType<"umbBlockGridDemoRichTextBlock", {
     richText: RichtextEditor;
 }>;
 
@@ -204,11 +204,11 @@ export type GridContentPage = BaseDocumentType<"gridContentPage", Metadata["prop
     blocks?: GridContentPageBlocksBlockGrid;
 }>;
 
-export type MediaBlock = BaseDocumentType<"mediaBlock", {
+export type MediaBlock = BaseElementType<"mediaBlock", {
     media: (MediaPickerItem<ImageWithProps> | MediaPickerItem<File> | MediaPickerItem<UmbracoMediaArticle> | MediaPickerItem<UmbracoMediaAudio> | MediaPickerItem<UmbracoMediaVectorGraphics> | MediaPickerItem<Image> | MediaPickerItem<Folder> | MediaPickerItem<UmbracoMediaVideo>)[];
 }>;
 
-export type Metadata = BaseDocumentType<"metadata", {
+export type Metadata = BaseElementType<"metadata", {
     meta_description?: string;
     meta_image?: MediaPickerItem<Image, [
         Crop<"minimal", 1200, 630>
@@ -224,29 +224,29 @@ export type SiteRoot = BaseDocumentType<"siteRoot", Metadata["properties"] & Pag
     footer_bottom_menu?: UrlItem[];
 }>;
 
-export type UmbBlockGridDemoImageBlock = BaseDocumentType<"umbBlockGridDemoImageBlock", {
+export type UmbBlockGridDemoImageBlock = BaseElementType<"umbBlockGridDemoImageBlock", {
     image: MediaPickerItem<Image>[];
 }>;
 
-export type PageSettings = BaseDocumentType<"pageSettings", {
+export type PageSettings = BaseElementType<"pageSettings", {
     umbracoUrlName?: string;
     excludeSearchResult?: boolean;
 }>;
 
-export type UmbBlockGridDemoHeadlineBlock = BaseDocumentType<"umbBlockGridDemoHeadlineBlock", {
+export type UmbBlockGridDemoHeadlineBlock = BaseElementType<"umbBlockGridDemoHeadlineBlock", {
     headline: string;
 }>;
 
-export type LinkGroup = BaseDocumentType<"linkGroup", {
+export type LinkGroup = BaseElementType<"linkGroup", {
     title: string;
     items?: NavigationBlockList;
 }>;
 
-export type RteBlock = BaseDocumentType<"rteBlock", {
+export type RteBlock = BaseElementType<"rteBlock", {
     nestedProperty: string;
 }>;
 
-export type FormBlock = BaseDocumentType<"formBlock", {
+export type FormBlock = BaseElementType<"formBlock", {
     form: {
         id: string;
         form: UmbracoForm;
@@ -258,7 +258,7 @@ export type PickableDocumentType = ContentPage | GridContentPage | SiteRoot;
 `;
 
 exports[`buildTypes > should resolve custom handlers by EditorUiAlias 1`] = `
-"import { type BaseDocumentType, type EmptyObjectType, type BaseGridBlockType, type BaseBlockType, type BaseGridBlockAreaType, type BaseBlockListType, type BaseBlockGridType, type BaseMediaType, type Crop, type MediaPickerItem } from "./base-types";
+"import { type BaseDocumentType, type BaseElementType, type EmptyObjectType, type BaseGridBlockType, type BaseBlockType, type BaseGridBlockAreaType, type BaseBlockListType, type BaseBlockGridType, type BaseMediaType, type Crop, type MediaPickerItem } from "./base-types";
 import { type UmbracoForm } from "./form";
 
 export interface UrlItem {
@@ -439,21 +439,21 @@ export type UmbracoMediaVideo = BaseMediaType<"umbracoMediaVideo", {
 
 export type PickableMediaType = ImageWithProps | File | UmbracoMediaArticle | UmbracoMediaAudio | UmbracoMediaVectorGraphics | Image | Folder | UmbracoMediaVideo;
 
-export type UmbBlockGridDemoTwoColumnLayoutBlock = BaseDocumentType<"umbBlockGridDemoTwoColumnLayoutBlock", EmptyObjectType>;
+export type UmbBlockGridDemoTwoColumnLayoutBlock = BaseElementType<"umbBlockGridDemoTwoColumnLayoutBlock", EmptyObjectType>;
 
 export type ContentPage = BaseDocumentType<"contentPage", Metadata["properties"] & PageSettings["properties"] & {
     blocks?: ContentBlockList;
 }>;
 
-export type LinkItem = BaseDocumentType<"linkItem", {
+export type LinkItem = BaseElementType<"linkItem", {
     link: UrlItem;
 }>;
 
-export type RichtextBlock = BaseDocumentType<"richtextBlock", {
+export type RichtextBlock = BaseElementType<"richtextBlock", {
     content?: RichtextEditor;
 }>;
 
-export type UmbBlockGridDemoRichTextBlock = BaseDocumentType<"umbBlockGridDemoRichTextBlock", {
+export type UmbBlockGridDemoRichTextBlock = BaseElementType<"umbBlockGridDemoRichTextBlock", {
     richText: RichtextEditor;
 }>;
 
@@ -461,11 +461,11 @@ export type GridContentPage = BaseDocumentType<"gridContentPage", Metadata["prop
     blocks?: GridContentPageBlocksBlockGrid;
 }>;
 
-export type MediaBlock = BaseDocumentType<"mediaBlock", {
+export type MediaBlock = BaseElementType<"mediaBlock", {
     media: (MediaPickerItem<ImageWithProps> | MediaPickerItem<File> | MediaPickerItem<UmbracoMediaArticle> | MediaPickerItem<UmbracoMediaAudio> | MediaPickerItem<UmbracoMediaVectorGraphics> | MediaPickerItem<Image> | MediaPickerItem<Folder> | MediaPickerItem<UmbracoMediaVideo>)[];
 }>;
 
-export type Metadata = BaseDocumentType<"metadata", {
+export type Metadata = BaseElementType<"metadata", {
     meta_description?: string;
     meta_image?: MediaPickerItem<Image, [
         Crop<"minimal", 1200, 630>
@@ -481,29 +481,29 @@ export type SiteRoot = BaseDocumentType<"siteRoot", Metadata["properties"] & Pag
     footer_bottom_menu?: UrlItem[];
 }>;
 
-export type UmbBlockGridDemoImageBlock = BaseDocumentType<"umbBlockGridDemoImageBlock", {
+export type UmbBlockGridDemoImageBlock = BaseElementType<"umbBlockGridDemoImageBlock", {
     image: MediaPickerItem<Image>[];
 }>;
 
-export type PageSettings = BaseDocumentType<"pageSettings", {
+export type PageSettings = BaseElementType<"pageSettings", {
     umbracoUrlName?: string;
     excludeSearchResult?: boolean;
 }>;
 
-export type UmbBlockGridDemoHeadlineBlock = BaseDocumentType<"umbBlockGridDemoHeadlineBlock", {
+export type UmbBlockGridDemoHeadlineBlock = BaseElementType<"umbBlockGridDemoHeadlineBlock", {
     headline: string;
 }>;
 
-export type LinkGroup = BaseDocumentType<"linkGroup", {
+export type LinkGroup = BaseElementType<"linkGroup", {
     title: string;
     items?: NavigationBlockList;
 }>;
 
-export type RteBlock = BaseDocumentType<"rteBlock", {
+export type RteBlock = BaseElementType<"rteBlock", {
     nestedProperty: string;
 }>;
 
-export type FormBlock = BaseDocumentType<"formBlock", {
+export type FormBlock = BaseElementType<"formBlock", {
     form: {
         id: string;
         form: UmbracoForm;
@@ -515,7 +515,7 @@ export type PickableDocumentType = ContentPage | GridContentPage | SiteRoot;
 `;
 
 exports[`buildTypes > should support disabling data type alias emission 1`] = `
-"import { type BaseDocumentType, type EmptyObjectType, type BaseGridBlockType, type BaseBlockType, type BaseGridBlockAreaType, type BaseBlockListType, type BaseBlockGridType, type BaseMediaType, type Crop, type MediaPickerItem } from "./base-types";
+"import { type BaseDocumentType, type BaseElementType, type EmptyObjectType, type BaseGridBlockType, type BaseBlockType, type BaseGridBlockAreaType, type BaseBlockListType, type BaseBlockGridType, type BaseMediaType, type Crop, type MediaPickerItem } from "./base-types";
 import { type UmbracoForm } from "./form";
 
 export interface UrlItem {
@@ -636,21 +636,21 @@ export type UmbracoMediaVideo = BaseMediaType<"umbracoMediaVideo", {
 
 export type PickableMediaType = ImageWithProps | File | UmbracoMediaArticle | UmbracoMediaAudio | UmbracoMediaVectorGraphics | Image | Folder | UmbracoMediaVideo;
 
-export type UmbBlockGridDemoTwoColumnLayoutBlock = BaseDocumentType<"umbBlockGridDemoTwoColumnLayoutBlock", EmptyObjectType>;
+export type UmbBlockGridDemoTwoColumnLayoutBlock = BaseElementType<"umbBlockGridDemoTwoColumnLayoutBlock", EmptyObjectType>;
 
 export type ContentPage = BaseDocumentType<"contentPage", Metadata["properties"] & PageSettings["properties"] & {
     blocks?: ContentBlockList;
 }>;
 
-export type LinkItem = BaseDocumentType<"linkItem", {
+export type LinkItem = BaseElementType<"linkItem", {
     link: unknown;
 }>;
 
-export type RichtextBlock = BaseDocumentType<"richtextBlock", {
+export type RichtextBlock = BaseElementType<"richtextBlock", {
     content?: RichtextEditor;
 }>;
 
-export type UmbBlockGridDemoRichTextBlock = BaseDocumentType<"umbBlockGridDemoRichTextBlock", {
+export type UmbBlockGridDemoRichTextBlock = BaseElementType<"umbBlockGridDemoRichTextBlock", {
     richText: RichtextEditor;
 }>;
 
@@ -658,11 +658,11 @@ export type GridContentPage = BaseDocumentType<"gridContentPage", Metadata["prop
     blocks?: GridContentPageBlocksBlockGrid;
 }>;
 
-export type MediaBlock = BaseDocumentType<"mediaBlock", {
+export type MediaBlock = BaseElementType<"mediaBlock", {
     media: (MediaPickerItem<ImageWithProps> | MediaPickerItem<File> | MediaPickerItem<UmbracoMediaArticle> | MediaPickerItem<UmbracoMediaAudio> | MediaPickerItem<UmbracoMediaVectorGraphics> | MediaPickerItem<Image> | MediaPickerItem<Folder> | MediaPickerItem<UmbracoMediaVideo>)[];
 }>;
 
-export type Metadata = BaseDocumentType<"metadata", {
+export type Metadata = BaseElementType<"metadata", {
     meta_description?: string;
     meta_image?: MediaPickerItem<Image, [
         Crop<"minimal", 1200, 630>
@@ -678,29 +678,29 @@ export type SiteRoot = BaseDocumentType<"siteRoot", Metadata["properties"] & Pag
     footer_bottom_menu?: UrlItem[];
 }>;
 
-export type UmbBlockGridDemoImageBlock = BaseDocumentType<"umbBlockGridDemoImageBlock", {
+export type UmbBlockGridDemoImageBlock = BaseElementType<"umbBlockGridDemoImageBlock", {
     image: MediaPickerItem<Image>[];
 }>;
 
-export type PageSettings = BaseDocumentType<"pageSettings", {
+export type PageSettings = BaseElementType<"pageSettings", {
     umbracoUrlName?: string;
     excludeSearchResult?: boolean;
 }>;
 
-export type UmbBlockGridDemoHeadlineBlock = BaseDocumentType<"umbBlockGridDemoHeadlineBlock", {
+export type UmbBlockGridDemoHeadlineBlock = BaseElementType<"umbBlockGridDemoHeadlineBlock", {
     headline: string;
 }>;
 
-export type LinkGroup = BaseDocumentType<"linkGroup", {
+export type LinkGroup = BaseElementType<"linkGroup", {
     title: string;
     items?: NavigationBlockList;
 }>;
 
-export type RteBlock = BaseDocumentType<"rteBlock", {
+export type RteBlock = BaseElementType<"rteBlock", {
     nestedProperty: string;
 }>;
 
-export type FormBlock = BaseDocumentType<"formBlock", {
+export type FormBlock = BaseElementType<"formBlock", {
     form: {
         id: string;
         form: UmbracoForm;

--- a/src/lib/build-types.spec.ts
+++ b/src/lib/build-types.spec.ts
@@ -17,7 +17,7 @@ describe('buildTypes', () => {
 
 		const actual = printType(output.map((e) => e));
 		expect(actual.trim()).toMatchInlineSnapshot(`
-			"import { type BaseDocumentType, type EmptyObjectType, type BaseGridBlockType, type BaseBlockType, type BaseGridBlockAreaType, type BaseBlockListType, type BaseBlockGridType, type BaseMediaType, type Crop, type MediaPickerItem } from "./base-types";
+			"import { type BaseDocumentType, type BaseElementType, type EmptyObjectType, type BaseGridBlockType, type BaseBlockType, type BaseGridBlockAreaType, type BaseBlockListType, type BaseBlockGridType, type BaseMediaType, type Crop, type MediaPickerItem } from "./base-types";
 			import { type UmbracoForm } from "./form";"
 		`);
 	});

--- a/src/lib/build-types.ts
+++ b/src/lib/build-types.ts
@@ -66,6 +66,11 @@ export function buildTypes(context: HandlerContext & BuildTypesOptions): ts.Node
 					ts.factory.createImportSpecifier(
 						true,
 						undefined,
+						ts.factory.createIdentifier('BaseElementType'),
+					),
+					ts.factory.createImportSpecifier(
+						true,
+						undefined,
 						ts.factory.createIdentifier('EmptyObjectType'),
 					),
 					ts.factory.createImportSpecifier(

--- a/src/lib/documenttypes/index.ts
+++ b/src/lib/documenttypes/index.ts
@@ -99,7 +99,9 @@ function build(documentType: DocumentType, { artifacts, dataTypeHandlers }: Hand
 			factory.createIdentifier(variableIdentifier),
 			undefined,
 			factory.createTypeReferenceNode(
-				factory.createIdentifier('BaseDocumentType'),
+				documentType.Permissions.IsElementType
+					? factory.createIdentifier('BaseElementType')
+					: factory.createIdentifier('BaseDocumentType'),
 				[
 					factory.createLiteralTypeNode(factory.createStringLiteral(documentType.Alias)),
 					documentProperties,

--- a/templates/base-types.ts
+++ b/templates/base-types.ts
@@ -62,22 +62,28 @@ export type MediaPickerItem<T extends BaseMediaType = BaseMediaType, C extends C
 		: C;
 };
 
-export interface BaseDocumentType<
+export interface BaseElementType<
+	Alias extends string = string,
+	Properties extends ObjectType = ObjectType,
+> {
+	id: string;
+	contentType: Alias;
+	properties: Properties;
+}
+
+export type BaseDocumentType<
 	Alias extends string = string,
 	Properties extends ObjectType = ObjectType,
 	Cultures extends { [culture: string]: ContentRoute } = EmptyObjectType,
-> {
-	id: string;
+> = BaseElementType<Alias, Properties> & {
 	name: string;
 	createDate: string;
 	updateDate: string;
 	route: ContentRoute;
-	contentType: Alias;
 	cultures: Cultures;
-	properties: Properties;
-}
+};
 
-export interface BaseBlockType<Content extends BaseDocumentType = BaseDocumentType, Setting extends BaseDocumentType | null = BaseDocumentType | null> {
+export interface BaseBlockType<Content extends BaseElementType = BaseElementType, Setting extends BaseElementType | null = BaseElementType | null> {
 	content: Content;
 	settings: Setting;
 }
@@ -86,14 +92,14 @@ export interface BaseBlockListType<Block extends BaseBlockType = BaseBlockType> 
 	items: Block[];
 }
 
-export interface BaseBlockGridType<Block extends BaseGridBlockType<BaseDocumentType, BaseDocumentType | null, BaseGridBlockAreaType[]> = BaseGridBlockType> {
+export interface BaseBlockGridType<Block extends BaseGridBlockType<BaseElementType, BaseElementType | null, BaseGridBlockAreaType[]> = BaseGridBlockType> {
 	gridColumns: number;
 	items: Block[];
 }
 
 export interface BaseGridBlockType<
-	Content extends BaseDocumentType = BaseDocumentType,
-	Setting extends BaseDocumentType | null = BaseDocumentType | null,
+	Content extends BaseElementType = BaseElementType,
+	Setting extends BaseElementType | null = BaseElementType | null,
 	Areas extends BaseGridBlockAreaType[] = never[],
 > extends BaseBlockType<Content, Setting> {
 	rowSpan: number;

--- a/templates/utils.ts
+++ b/templates/utils.ts
@@ -1,4 +1,4 @@
-import type { BaseBlockGridType, BaseBlockListType, BaseBlockType, BaseDocumentType, BaseGridBlockType, BaseMediaType, EmptyObjectType, ObjectType } from './base-types';
+import type { BaseBlockGridType, BaseBlockListType, BaseBlockType, BaseDocumentType, BaseElementType, BaseGridBlockType, BaseMediaType, EmptyObjectType, ObjectType } from './base-types';
 import type { UmbracoForm } from './form';
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
@@ -79,7 +79,7 @@ export type UnexpandBlockGrid<
  * // type ExpandableKeys = 'foo' | 'bar';
  * ```
  */
-export type ExpandableDocumentKeys<Doc extends BaseDocumentType> = Doc extends unknown
+export type ExpandableDocumentKeys<Doc extends BaseElementType> = Doc extends unknown
 	? ExpandablePropertyKeys<Doc['properties']>
 	: never;
 
@@ -162,8 +162,8 @@ export type UnexpandPropertyExpandables<Doc extends ObjectType, BlackListedKeys 
  * @param Doc The document type to unexpand.
  * @param BlackListedKeys The keys that should not be unexpanded.
  */
-export type UnexpandDocumentExpandables<Doc extends BaseDocumentType, BlackListedKeys extends ExpandableDocumentKeys<Doc> | undefined> = Doc extends unknown
-	? BaseDocumentType<Doc['contentType'], UnexpandPropertyExpandables<Doc['properties'], BlackListedKeys>>
+export type UnexpandDocumentExpandables<Doc extends BaseElementType, BlackListedKeys extends ExpandableDocumentKeys<Doc> | undefined> = Doc extends unknown
+	? BaseElementType<Doc['contentType'], UnexpandPropertyExpandables<Doc['properties'], BlackListedKeys>>
 	: never;
 
 export type ExpandParam<Doc extends BaseDocumentType> = ExpandableDocumentKeys<Doc>[] | '$all' | undefined | [];
@@ -177,12 +177,12 @@ export type ExpandResult<Doc extends BaseDocumentType, Param extends ExpandParam
 				: UnexpandDocumentExpandables<Doc, Param[number]>
 			: Doc;
 
-type DocFields<T extends BaseDocumentType> = keyof T['properties'];
+type DocFields<T extends BaseElementType> = keyof T['properties'];
 
-export type Fields<T extends BaseDocumentType> = ['$all'] | (DocFields<T> | {
-	[K in Exclude<ExpandableDocumentKeys<T>, undefined>]?: NonNullable<T['properties'][K]> extends BaseDocumentType[]
+export type Fields<T extends BaseElementType> = ['$all'] | (DocFields<T> | {
+	[K in Exclude<ExpandableDocumentKeys<T>, undefined>]?: NonNullable<T['properties'][K]> extends BaseElementType[]
 		? Fields<NonNullable<T['properties'][K]>[number]>
-		: NonNullable<T['properties'][K]> extends BaseDocumentType
+		: NonNullable<T['properties'][K]> extends BaseElementType
 			? Fields<NonNullable<T['properties'][K]>>
 			: never;
 })[];


### PR DESCRIPTION
### Description of change

Removes properties from elements which are not emitted from Umbraco. Introduces a `BaseElementType` which is used by documents with "Is an Element Type" enabled. BaseElementType is a base type for `BaseDocumentType`.

Closes: #6
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
