### PR TITLE
fix: correct BaseGridBlockAreaType constraint to use BaseElementType

### DIFF
--- a/src/__tests__/templates/base-types.spec.ts
+++ b/src/__tests__/templates/base-types.spec.ts
@@ -1,0 +1,90 @@
+import { assertType, describe, it } from 'vitest';
+
+import type { BaseBlockGridType, BaseDocumentType, BaseElementType, BaseGridBlockAreaType, BaseGridBlockType } from '../../../templates/base-types';
+
+// Concrete element types that mirror what the generator produces for block grid content.
+// These are BaseElementType (not BaseDocumentType) because block content is always element-level.
+type HeadlineElement = BaseElementType<'headline', { title: string }>;
+type RichTextElement = BaseElementType<'richtext', { body: string }>;
+
+// A grid block using element-type content and no settings.
+type HeadlineBlock = BaseGridBlockType<HeadlineElement, null>;
+type RichTextBlock = BaseGridBlockType<RichTextElement, null>;
+
+// An area containing element-type blocks — this is the line that would fail to compile
+// if BaseGridBlockAreaType incorrectly constrains Block to BaseDocumentType.
+type LeftArea = BaseGridBlockAreaType<'left', HeadlineBlock | RichTextBlock>;
+
+// A layout block whose areas contain the element-type blocks above.
+type TwoColumnElement = BaseElementType<'twoColumnLayout', Record<string, never>>;
+type TwoColumnBlock = BaseGridBlockType<TwoColumnElement, null, LeftArea[]>;
+
+// The full grid type.
+type TestGrid = BaseBlockGridType<TwoColumnBlock>;
+
+describe('baseGridBlockAreaType constraint', () => {
+	it('should accept grid blocks with BaseElementType content', () => {
+		// The Block parameter of BaseGridBlockAreaType must accept blocks whose
+		// content is BaseElementType. Before the fix, this would produce TS2344
+		// because the constraint required BaseDocumentType.
+		assertType<LeftArea>({
+			alias: 'left',
+			rowSpan: 1,
+			columnSpan: 6,
+			items: [] as (HeadlineBlock | RichTextBlock)[],
+		});
+	});
+
+	it('should compose into a full block grid type without type errors', () => {
+		// Ensure the complete grid hierarchy (grid → block → area → block) compiles
+		// when all content types are element types. This mirrors the typical output
+		// of the code generator for block grid configurations.
+		const area: LeftArea = {
+			alias: 'left',
+			rowSpan: 1,
+			columnSpan: 6,
+			items: [],
+		};
+
+		const block: TwoColumnBlock = {
+			content: { id: '1', contentType: 'twoColumnLayout', properties: {} },
+			settings: null,
+			rowSpan: 1,
+			columnSpan: 12,
+			areaGridColumns: 12,
+			areas: [area],
+		};
+
+		assertType<TestGrid>({
+			gridColumns: 12,
+			items: [block],
+		});
+	});
+
+	it('should not accept BaseDocumentType where only BaseElementType is expected', () => {
+		// BaseDocumentType extends BaseElementType with extra fields (name, createDate, etc.).
+		// Grid block content types are elements, not documents. Verify that the constraint
+		// on BaseGridBlockType's Content parameter does not require BaseDocumentType.
+		type DocElement = BaseDocumentType<'doc', { title: string }>;
+		type DocBlock = BaseGridBlockType<DocElement, null>;
+
+		// BaseDocumentType satisfies BaseElementType, so a document-type block can still
+		// be used in an area — this direction should compile fine.
+		assertType<BaseGridBlockAreaType<'test', DocBlock>>({
+			alias: 'test',
+			rowSpan: 1,
+			columnSpan: 6,
+			items: [],
+		});
+
+		// But an area accepting element-type blocks should NOT accept being narrowed
+		// to only document-type blocks, since element types lack the document fields.
+		assertType<LeftArea>({
+			alias: 'left',
+			rowSpan: 1,
+			columnSpan: 6,
+			// @ts-expect-error DocBlock content is BaseDocumentType which is narrower than HeadlineBlock | RichTextBlock
+			items: [] as DocBlock[],
+		});
+	});
+});

--- a/src/lib/__snapshots__/build-types.spec.ts.snap
+++ b/src/lib/__snapshots__/build-types.spec.ts.snap
@@ -88,7 +88,6 @@ export type MetaDescriptionTextarea = string;
 export type TrueFalse = boolean;
 export type LabelBigint = number;
 export type LabelTime = string;
-export type ListViewMembers = unknown;
 export type ImageMediaPicker = MediaPickerItem<Image>[];
 export type MultiUrlPicker = UrlItem[];
 export type Tags = string[];
@@ -107,6 +106,7 @@ export type LabelString = string;
 export type DropdownMultiple = string[];
 export type CheckboxList = string[];
 export type ContentPicker = PickableDocumentType | null;
+export type ListViewMembers = unknown;
 
 export type ImageWithProps = BaseMediaType<"ImageWithProps", {
     altText?: string;
@@ -345,7 +345,6 @@ export type MetaDescriptionTextarea = string;
 export type TrueFalse = boolean;
 export type LabelBigint = number;
 export type LabelTime = string;
-export type ListViewMembers = unknown;
 export type ImageMediaPicker = MediaPickerItem<Image>[];
 export type MultiUrlPicker = UrlItem[];
 export type Tags = string[];
@@ -364,6 +363,7 @@ export type LabelString = string;
 export type DropdownMultiple = string[];
 export type CheckboxList = string[];
 export type ContentPicker = PickableDocumentType | null;
+export type ListViewMembers = unknown;
 
 export type ImageWithProps = BaseMediaType<"ImageWithProps", {
     altText?: string;

--- a/templates/base-types.ts
+++ b/templates/base-types.ts
@@ -108,7 +108,7 @@ export interface BaseGridBlockType<
 	areas: Areas;
 }
 
-export interface BaseGridBlockAreaType<Alias extends string = string, Block extends BaseGridBlockType<BaseDocumentType, BaseDocumentType | null, never[]> = BaseGridBlockType<BaseDocumentType, BaseDocumentType | null, never[]>> {
+export interface BaseGridBlockAreaType<Alias extends string = string, Block extends BaseGridBlockType<BaseElementType, BaseElementType | null, never[]> = BaseGridBlockType<BaseElementType, BaseElementType | null, never[]>> {
 	alias: Alias;
 	rowSpan: number;
 	columnSpan: number;


### PR DESCRIPTION
### Description of change

The bug: BaseGridBlockAreaType was constraining its Block parameter to BaseDocumentType, but grid blocks actually contain BaseElementType content. This caused TypeScript errors when using element-type blocks in grid areas.

The fix: Changed the constraint from BaseDocumentType to BaseElementType to match what the other grid-related types already use (BaseBlockGridType and BaseGridBlockType).

Tests added: Three type-level tests verify that element-type blocks work correctly in grid areas and compose properly through the full grid hierarchy.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
