### PR TITLE
Block settings expansion

### DIFF
--- a/src/__tests__/templates/unexpand-block-list.spec.ts
+++ b/src/__tests__/templates/unexpand-block-list.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { BaseBlockListType, BaseBlockType, BaseDocumentType, BaseElementType, EmptyObjectType } from '../../../templates/base-types';
+import type { ExpandableElementKeys, UnexpandBlock, UnexpandBlockList } from '../../../templates/utils';
+
+type NestedChildPage = BaseDocumentType<'nestedChildPage', {
+	headline: string;
+}>;
+
+type ChildPage = BaseDocumentType<'childPage', {
+	headline: string;
+	child: NestedChildPage;
+}>;
+
+type HeadlineElement = BaseElementType<'headline', { title: string }>;
+type RichTextElement = BaseElementType<'richtext', { body: string }>;
+type ChildElement = BaseElementType<'child', {
+	child: ChildPage[];
+}>;
+
+type HeadlineBlock = BaseBlockType<HeadlineElement, null>;
+type RichTextBlock = BaseBlockType<RichTextElement, null>;
+type ChildBlock = BaseBlockType<ChildElement, null>;
+
+type ContentBlockList = BaseBlockListType<HeadlineBlock | RichTextBlock | ChildBlock>;
+
+describe('type UnexpandBlockList', () => {
+	it('should not unexpand when expandable properties are passed', () => {
+		type Actual = ContentBlockList;
+		expectTypeOf<Actual>().toEqualTypeOf<UnexpandBlockList<ContentBlockList, ExpandableElementKeys<ContentBlockList['items'][number]['content']>>>();
+		expectTypeOf<Actual>().toEqualTypeOf<UnexpandBlockList<ContentBlockList, 'child'>>();
+	});
+
+	it('should unexpand when expand is undefined', () => {
+		type Actual = BaseBlockListType<HeadlineBlock | RichTextBlock | BaseBlockType<BaseElementType<'child', {
+			child: BaseDocumentType<'childPage', EmptyObjectType>[];
+		}>, null>>;
+
+		expectTypeOf<Actual>().toEqualTypeOf<UnexpandBlockList<ContentBlockList, undefined>>();
+	});
+
+	it('should handle blocks with blockSettings', () => {
+		type BlockSettingsElement = BaseElementType<'blockSettings', { anchor?: string }>;
+		type HeadlineBlockWithSettings = BaseBlockType<HeadlineElement, BlockSettingsElement>;
+
+		type ContentBlockListWithSettings = BaseBlockListType<HeadlineBlockWithSettings | RichTextBlock | ChildBlock>;
+
+		type Actual = BaseBlockListType<UnexpandBlock<HeadlineBlockWithSettings, ExpandableElementKeys<HeadlineBlockWithSettings['content']>> | RichTextBlock | ChildBlock>;
+
+		expectTypeOf<Actual>().toEqualTypeOf<UnexpandBlockList<ContentBlockListWithSettings, 'child'>>();
+		expectTypeOf<UnexpandBlockList<ContentBlockListWithSettings, 'child'>>().toEqualTypeOf<UnexpandBlockList<ContentBlockListWithSettings, 'child'>>();
+	});
+});

--- a/src/__tests__/templates/utils.spec.ts
+++ b/src/__tests__/templates/utils.spec.ts
@@ -1,6 +1,6 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest';
 
-import type { BaseBlockListType, BaseBlockType, BaseDocumentType, BaseElementType, EmptyObjectType } from '../../../templates/base-types';
+import type { BaseBlockListType, BaseBlockType, BaseDocumentType, BaseElementType } from '../../../templates/base-types';
 import type { ExpandParam, ExpandResult, ExpandableElementKeys, OmitFields, UnexpandBlockList, UnexpandDocumentExpandables, UnexpandPropertyExpandables } from '../../../templates/utils';
 
 type NestedChildPage = BaseDocumentType<'nestedChildPage', {
@@ -14,11 +14,12 @@ type ChildPage = BaseDocumentType<'childPage', {
 
 type HeadlineElement = BaseElementType<'headline', { title: string }>;
 type RichTextElement = BaseElementType<'richtext', { body: string }>;
+type BlockSettingsElement = BaseElementType<'blockSettings', { body: string }>;
 type ChildElement = BaseElementType<'child', {
 	child: ChildPage[];
 }>;
 
-type HeadlineBlock = BaseBlockType<HeadlineElement, null>;
+type HeadlineBlock = BaseBlockType<HeadlineElement, BlockSettingsElement>;
 type RichTextBlock = BaseBlockType<RichTextElement, null>;
 type ChildBlock = BaseBlockType<ChildElement, null>;
 
@@ -118,29 +119,15 @@ describe('type ExpandResult', () => {
 		expectTypeOf<ContentPage>().toEqualTypeOf<ExpandResult<OmitFields<ContentPage, ['$all']>, ['blocks']>>();
 		expectTypeOf<ContentPage>().toEqualTypeOf<ExpandResult<OmitFields<ContentPage, ['headline' | 'blocks']>, ['blocks']>>();
 	});
-});
 
-describe('type UnexpandBlockList', () => {
-	it('should not unexpand when expandable properties are passed', () => {
-		type Actual = ContentBlockList;
-		expectTypeOf<Actual>().toEqualTypeOf<UnexpandBlockList<ContentBlockList, ExpandableElementKeys<ContentBlockList['items'][number]['content']>>>();
-		expectTypeOf<Actual>().toEqualTypeOf<UnexpandBlockList<ContentBlockList, 'child'>>();
-	});
+	describe('type UnexpandBlockList', () => {
+		it('should unexpand all when expand is undefined', () => {
+			type Actual = BaseDocumentType<'contentPage', {
+				headline: string;
+				blocks: UnexpandBlockList<ContentBlockList, 'child'>;
+			}>;
 
-	it('should unexpand when expand is undefined', () => {
-		type Actual = BaseBlockListType<HeadlineBlock | RichTextBlock | BaseBlockType<BaseElementType<'child', {
-			child: BaseDocumentType<'childPage', EmptyObjectType>[];
-		}>, null>>;
-
-		expectTypeOf<Actual>().toEqualTypeOf<UnexpandBlockList<ContentBlockList, undefined>>();
-	});
-
-	it('should unexpand all when expand is undefined', () => {
-		type Actual = BaseDocumentType<'contentPage', {
-			headline: string;
-			blocks: UnexpandBlockList<ContentBlockList, undefined>;
-		}>;
-
-		expectTypeOf<Actual>().toEqualTypeOf<ExpandResult<ContentPage, undefined>>();
+			expectTypeOf<Actual>().toEqualTypeOf<ExpandResult<ContentPage, '$all'>>();
+		});
 	});
 });

--- a/templates/base-types.ts
+++ b/templates/base-types.ts
@@ -85,7 +85,9 @@ export type BaseDocumentType<
 
 export interface BaseBlockType<Content extends BaseElementType = BaseElementType, Setting extends BaseElementType | null = BaseElementType | null> {
 	content: Content;
-	settings: Setting;
+	settings: Setting extends unknown
+		? Setting
+		: never;
 }
 
 export interface BaseBlockListType<Block extends BaseBlockType = BaseBlockType> {

--- a/templates/utils.ts
+++ b/templates/utils.ts
@@ -37,8 +37,8 @@ type MaybeUnexpandDoc<Doc extends BaseDocumentType | null, BlackListedKeys exten
 export type UnexpandBlock<Block extends BaseBlockType, BlackListedKeys extends ExpandableElementKeys<NonNullable<Block['content']>> | undefined> = Block extends unknown
 	? BaseBlockType<
 		UnexpandElementExpandables<Block['content'], BlackListedKeys>,
-		Block['settings'] extends BaseDocumentType
-			? UnexpandDocumentExpandables<Block['settings'], BlackListedKeys>
+		Block['settings'] extends BaseElementType
+			? UnexpandElementExpandables<Block['settings'], BlackListedKeys>
 			: null
 	>
 	: never;

--- a/templates/utils.ts
+++ b/templates/utils.ts
@@ -34,7 +34,7 @@ type MaybeUnexpandDoc<Doc extends BaseDocumentType | null, BlackListedKeys exten
 		? BaseDocumentType<string, EmptyObjectType, EmptyObjectType>
 		: UnexpandDocumentExpandables<NonNullable<Doc>, BlackListedKeys>;
 
-export type UnexpandBlock<Block extends BaseBlockType, BlackListedKeys extends ExpandableElementKeys<NonNullable<Block['content']>> | undefined> = Block extends unknown
+export type UnexpandBlock<Block extends BaseBlockType, BlackListedKeys extends ExpandableBlockKeys<NonNullable<Block>> | undefined> = Block extends unknown
 	? BaseBlockType<
 		UnexpandElementExpandables<Block['content'], BlackListedKeys>,
 		Block['settings'] extends BaseElementType
@@ -45,21 +45,21 @@ export type UnexpandBlock<Block extends BaseBlockType, BlackListedKeys extends E
 
 export type UnexpandBlockList<
 	BlockList extends BaseBlockListType,
-	BlackListedKeys extends ExpandableElementKeys<BlockList['items'][number]['content']> | undefined,
+	BlackListedKeys extends ExpandableBlockKeys<BlockList['items'][number]> | undefined,
 > = BaseBlockListType<
 	UnexpandBlock<BlockList['items'][number], BlackListedKeys>
 >;
 
 export type UnexpandBlockGrid<
 	BlockGrid extends BaseBlockGridType,
-	BlackListedContentKeys extends ExpandableElementKeys<BlockGrid['items'][number]['content']> | undefined,
-	BlackListedSettingsKeys extends ExpandableElementKeys<NonNullable<BlockGrid['items'][number]['settings']>> | undefined,
+	BlackListedKeys extends ExpandableBlockKeys<BlockGrid['items'][number]> | undefined,
 > = BaseBlockGridType<
 	BaseGridBlockType<
-		UnexpandElementExpandables<BlockGrid['items'][number]['content'], BlackListedContentKeys>,
+		UnexpandElementExpandables<BlockGrid['items'][number]['content'], BlackListedKeys>,
 		BlockGrid['items'][number]['settings'] extends null
 			? null
-			: UnexpandElementExpandables<NonNullable<BlockGrid['items'][number]['settings']>, BlackListedSettingsKeys>
+			: UnexpandElementExpandables<NonNullable<BlockGrid['items'][number]['settings']>, BlackListedKeys>,
+		BlockGrid['items'][number]['areas']
 	>
 >;
 
@@ -81,6 +81,17 @@ export type UnexpandBlockGrid<
  */
 export type ExpandableElementKeys<Elm extends BaseElementType> = Elm extends unknown
 	? ExpandablePropertyKeys<Elm['properties']>
+	: never;
+
+/**
+ * Gets all expandable properties of a block type.
+ * Note that this is a single list for a Block content & settings even though they are structurally divided.
+ * See below [Umbraco property expansion docs](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/property-expansion-and-limiting#working-with-block-based-editors) for more.
+ */
+export type ExpandableBlockKeys<Block extends BaseBlockType> = Block extends unknown
+	? Block['settings'] extends BaseElementType
+		? ExpandableElementKeys<Block['content']> | ExpandableElementKeys<Block['settings']>
+		: ExpandableElementKeys<Block['content']>
 	: never;
 
 /**
@@ -119,9 +130,9 @@ type UnexpandNestedProperty<Prop> = Prop extends BaseDocumentType | null
 	: Prop extends BaseDocumentType[]
 		? UnexpandDocumentExpandables<Prop[number], ExpandableElementKeys<Prop[number]>>[]
 		: Prop extends BaseBlockGridType
-			? UnexpandBlockGrid<Prop, ExpandableElementKeys<Prop['items'][number]['content']>, ExpandableElementKeys<NonNullable<Prop['items'][number]['settings']>>>
+			? UnexpandBlockGrid<Prop, ExpandableBlockKeys<Prop['items'][number]>>
 			: Prop extends BaseBlockListType
-				? UnexpandBlockList<Prop, ExpandableElementKeys<Prop['items'][number]['content']>>
+				? UnexpandBlockList<Prop, ExpandableBlockKeys<Prop['items'][number]>>
 				: Prop;
 
 export type UnexpandProperty<Prop> = Prop extends BaseDocumentType | null
@@ -129,7 +140,7 @@ export type UnexpandProperty<Prop> = Prop extends BaseDocumentType | null
 	: Prop extends BaseDocumentType[]
 		? UnexpandDocumentType<Prop[number]>[]
 		: Prop extends BaseBlockGridType
-			? UnexpandBlockGrid<Prop, undefined, undefined>
+			? UnexpandBlockGrid<Prop, undefined>
 			: Prop extends BaseBlockListType
 				? UnexpandBlockList<Prop, undefined>
 				: Prop extends BaseBlockType


### PR DESCRIPTION
### Description of change

This PR resolves 2 issues:

1. Using `UnexpandBlockList` with blocks configured with `Settings` would error
2. Expand key detection for blocks did not match content delivery api.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
